### PR TITLE
Enhance mobile company dashboard and heatmap

### DIFF
--- a/src/app/companies/page.tsx
+++ b/src/app/companies/page.tsx
@@ -373,14 +373,17 @@ export default function CompaniesPage() {
         </div>
 
         {/* Dashboard Content */}
-        <div className="p-8 space-y-8 lg:p-8 pl-16 lg:pl-8">
+        <div className="p-4 space-y-6 sm:p-8 sm:space-y-8 pl-4 sm:pl-8">
           {/* Two Column Layout: Balanced Responsive Layout */}
           <div className="flex flex-col 2xl:flex-row gap-6 items-start space-y-6 2xl:space-y-0">
-            
+
             {/* Left Column: Added 20px to ensure weeks 51-52 are visible */}
-            <div className="w-full space-y-6 min-w-0" style={{ maxWidth: '800px' }}>
+            <div
+              className="w-full space-y-6 min-w-0"
+              style={{ maxWidth: isMobile ? '100%' : '800px' }}
+            >
               {/* Enhanced Heatmap - MASTER WIDTH COMPONENT */}
-              <EnhancedHeatmap 
+              <EnhancedHeatmap
                 selectedSection={selectedSection}
               />
               

--- a/src/components/companies/CompanyDashboard.tsx
+++ b/src/components/companies/CompanyDashboard.tsx
@@ -404,15 +404,18 @@ export default function CompanyDashboard({
         )}
 
         {/* Dashboard Content - Match main dashboard layout exactly */}
-        <div className="p-8 space-y-8">
+        <div className="p-4 space-y-6 sm:p-8 sm:space-y-8">
           {/* Two Column Layout: Balanced Responsive Layout */}
           <div className="flex flex-col 2xl:flex-row gap-6 items-start space-y-6 2xl:space-y-0">
-            
+
             {/* Left Column: Added 20px to ensure weeks 51-52 are visible */}
-            <div className="w-full space-y-6 min-w-0" style={{ maxWidth: '800px' }}>
+            <div
+              className="w-full space-y-6 min-w-0"
+              style={{ maxWidth: isMobile ? '100%' : '800px' }}
+            >
               {/* Enhanced Heatmap - Company-specific data (only show if data exists) */}
               {hasHeatmapData() && (
-                <EnhancedHeatmap 
+                <EnhancedHeatmap
                   selectedSection={isWolthersCompany ? 'wolthers' : (company.category === 'buyer' ? 'buyers' : company.category === 'supplier' ? 'suppliers' : 'buyers')}
                   companyId={company.id}
                   companyName={company.fantasy_name || company.name}


### PR DESCRIPTION
## Summary
- Make company and dashboard pages use full-width containers on mobile with responsive padding
- Render heatmap as scrollable weekly grid of squares with full Jan–Dec labels
- Keep mobile heatmap on a 12-column monthly layout with gaps equal to square size

## Testing
- `npm test` (fails: Missing script)
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_68b39c2a3574833384ed6ea26f020e4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Mobile-responsive Company Dashboard with tighter spacing on small screens.
  - Heatmap now adapts to the current year dynamically.
  - Automatic switch to a monthly view on small viewports with optimized square sizing and gaps.
  - Horizontal scrolling enabled for headers to improve navigation on narrow screens.
  - Improved header rendering: weekly, biannual, and monthly headers align with the selected layout.
  - Responsive left-column width for better readability on mobile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->