### PR TITLE
Move mobile add trip button into menu and fix modal scroll

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -14,27 +14,36 @@ import { useTrips } from '@/hooks/useTrips'
 import { useRequireAuth, useAuth } from '@/contexts/AuthContext'
 
 export default function Dashboard() {
-  const { isAuthenticated, isLoading: authLoading } = useRequireAuth()
-  const { user } = useAuth() // Get user data for permission checks
-  const [selectedTrip, setSelectedTrip] = useState<TripCardType | null>(null)
-  const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [showTripCreationModal, setShowTripCreationModal] = useState(false)
+    const { isAuthenticated, isLoading: authLoading } = useRequireAuth()
+    const { user } = useAuth() // Get user data for permission checks
+    const [selectedTrip, setSelectedTrip] = useState<TripCardType | null>(null)
+    const [isMenuOpen, setIsMenuOpen] = useState(false)
+    const [showTripCreationModal, setShowTripCreationModal] = useState(false)
   const [resumeData, setResumeData] = useState<any>(null)
   const [draftTrips, setDraftTrips] = useState<any[]>([])
   const [showPasswordPrompt, setShowPasswordPrompt] = useState(false)
   const [showUserPanel, setShowUserPanel] = useState(false)
-  const { trips, loading, error, isOffline, refetch } = useTrips()
+    const { trips, loading, error, isOffline, refetch } = useTrips()
 
-  // Listen for menu state changes (this would need to be coordinated with Header component)
-  // This useEffect must be called unconditionally to maintain hooks order
-  React.useEffect(() => {
-    const handleMenuToggle = (event: CustomEvent) => {
-      setIsMenuOpen(event.detail.isOpen)
-    }
-    
-    window.addEventListener('menuToggle', handleMenuToggle as EventListener)
-    return () => window.removeEventListener('menuToggle', handleMenuToggle as EventListener)
-  }, [])
+    // Listen for menu state changes (this would need to be coordinated with Header component)
+    // This useEffect must be called unconditionally to maintain hooks order
+    React.useEffect(() => {
+      const handleMenuToggle = (event: CustomEvent) => {
+        setIsMenuOpen(event.detail.isOpen)
+      }
+
+      window.addEventListener('menuToggle', handleMenuToggle as EventListener)
+      return () => window.removeEventListener('menuToggle', handleMenuToggle as EventListener)
+    }, [])
+
+    // Prevent background scrolling when trip overview modal is open
+    React.useEffect(() => {
+      if (selectedTrip) {
+        document.body.style.overflow = 'hidden'
+      } else {
+        document.body.style.overflow = ''
+      }
+    }, [selectedTrip])
 
   // Load draft trips
   React.useEffect(() => {
@@ -199,6 +208,15 @@ export default function Dashboard() {
     setShowTripCreationModal(true)
   }
 
+  // Open trip creation modal when triggered from Header
+  React.useEffect(() => {
+    const handleOpenTripCreation = () => {
+      handleCreateTrip()
+    }
+    window.addEventListener('openTripCreation', handleOpenTripCreation as EventListener)
+    return () => window.removeEventListener('openTripCreation', handleOpenTripCreation as EventListener)
+  }, [handleCreateTrip])
+
   const handleTripCreated = (trip: any) => {
     // Refresh trips data to show the newly created trip
     console.log('Trip created:', trip)
@@ -262,19 +280,6 @@ export default function Dashboard() {
             )}
           >
             <Plus className="w-8 h-8 text-gray-400 dark:text-golden-400 group-hover:text-golden-600 dark:group-hover:text-golden-300 transition-colors" />
-          </div>
-        </div>
-      )}
-
-      {/* Mobile Add Trip Button - fixed position below header but behind modals - Only show for authorized users */}
-      {canCreateTrips && (
-        <div className="fixed top-[135px] left-[55px] right-[55px] xl:hidden z-20">
-          <div
-            onClick={handleCreateTrip}
-            className="bg-white dark:bg-[#123d32] rounded-lg shadow-lg hover:shadow-xl border-2 border-dashed border-gray-300 dark:border-[#123d32] hover:border-golden-400 dark:hover:border-golden-400 hover:bg-golden-50 dark:hover:bg-[#0E3D2F] transition-all duration-300 cursor-pointer flex items-center justify-center group transform hover:-translate-y-1 w-full h-[50px]"
-          >
-            <Plus className="w-6 h-6 text-gray-400 dark:text-golden-400 group-hover:text-golden-600 dark:group-hover:text-golden-300 transition-colors" />
-            <span className="ml-2 text-sm font-medium text-gray-600 dark:text-golden-400 group-hover:text-golden-600 dark:group-hover:text-golden-300">Add New Trip</span>
           </div>
         </div>
       )}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,15 +6,16 @@ import { usePathname } from "next/navigation";
 import {
   Home,
   Building,
-  Users,
-  Settings,
-  Sun,
-  Moon,
-  Menu,
-  X,
-  User,
-  LogOut,
-} from "lucide-react";
+    Users,
+    Settings,
+    Sun,
+    Moon,
+    Menu,
+    X,
+    User,
+    LogOut,
+    Plus,
+  } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useTheme } from "@/contexts/ThemeContext";
 import { useAuth } from "@/contexts/AuthContext";
@@ -58,10 +59,20 @@ const navItems: NavItem[] = [
 export default function Header() {
   const pathname = usePathname();
   const { theme, toggleTheme } = useTheme();
-  const { user, signOut, isLoading } = useAuth();
-  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
-  const [showUserModal, setShowUserModal] = React.useState(false);
-  const [showUserDropdown, setShowUserDropdown] = React.useState(false);
+    const { user, signOut, isLoading } = useAuth();
+    const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+    const [showUserModal, setShowUserModal] = React.useState(false);
+    const [showUserDropdown, setShowUserDropdown] = React.useState(false);
+
+    // Determine if user can create trips
+    const canCreateTrips = React.useMemo(() => {
+      if (!user) return false;
+      const isWolthersStaff =
+        user.isGlobalAdmin ||
+        user.companyId === "840783f4-866d-4bdb-9b5d-5d0facf62db0";
+      if (isWolthersStaff) return true;
+      return user.role === "admin";
+    }, [user]);
 
   // Filter navigation items based on user permissions
   const getFilteredNavItems = () => {
@@ -279,11 +290,11 @@ export default function Header() {
           <div className="lg:hidden mt-4 mx-4 sm:mx-6">
             <div className="bg-emerald-800/95 dark:bg-[#09261d]/95 backdrop-blur-xl rounded-2xl shadow-2xl border border-emerald-600/30 dark:border-emerald-900/60 overflow-hidden">
               <div className="absolute inset-0 bg-gradient-to-b from-emerald-700/30 to-emerald-900/30 dark:from-[#09261d]/60 dark:to-[#041611]/80" />
-              <nav className="relative p-4 space-y-2">
-                {getFilteredNavItems().map((item) => (
-                  <Link
-                    key={item.href}
-                    href={item.href}
+                <nav className="relative p-4 space-y-2">
+                  {getFilteredNavItems().map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
                     onClick={() => {
                       setIsMenuOpen(false);
                       window.dispatchEvent(
@@ -302,14 +313,33 @@ export default function Header() {
                     {item.icon}
                     <span className="font-medium">{item.label}</span>
                   </Link>
-                ))}
+                  ))}
+
+                  {/* Add Trip Button for Mobile */}
+                  {canCreateTrips && (
+                    <button
+                      onClick={() => {
+                        window.dispatchEvent(new CustomEvent("openTripCreation"));
+                        setIsMenuOpen(false);
+                        window.dispatchEvent(
+                          new CustomEvent("menuToggle", {
+                            detail: { isOpen: false },
+                          }),
+                        );
+                      }}
+                      className="flex items-center space-x-3 p-3 rounded-xl text-emerald-100 dark:text-green-300 hover:text-white hover:bg-white/10 dark:hover:bg-emerald-500/15 transition-all duration-200 w-full text-left"
+                    >
+                      <Plus className="w-5 h-5" />
+                      <span className="font-medium">Add Trip</span>
+                    </button>
+                  )}
 
                 {/* User Profile for Mobile */}
-                {user && !isLoading && (
-                  <button
-                    onClick={() => {
-                      setShowUserModal(true);
-                      setIsMenuOpen(false);
+                  {user && !isLoading && (
+                    <button
+                      onClick={() => {
+                        setShowUserModal(true);
+                        setIsMenuOpen(false);
                       window.dispatchEvent(
                         new CustomEvent("menuToggle", {
                           detail: { isOpen: false },


### PR DESCRIPTION
## Summary
- Move mobile add trip action into hamburger menu
- Listen for global openTripCreation event and disable background scrolling when QuickViewModal is open
- Remove floating add-trip button from dashboard mobile view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(terminated: command hung during Next.js build)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b05fd0a48333934115df6e3cba34