### PR TITLE
Fix trip overview scrolling on mobile

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -38,10 +38,17 @@ export default function Dashboard() {
 
     // Prevent background scrolling when trip overview modal is open
     React.useEffect(() => {
+      const html = document.documentElement
+      const body = document.body
+
       if (selectedTrip) {
-        document.body.style.overflow = 'hidden'
+        // Lock scroll on both the html and body elements
+        html.style.overflow = 'hidden'
+        body.style.overflow = 'hidden'
       } else {
-        document.body.style.overflow = ''
+        // Restore default scrolling
+        html.style.overflow = ''
+        body.style.overflow = ''
       }
     }, [selectedTrip])
 


### PR DESCRIPTION
## Summary
- prevent background dashboard scrolling when trip overview modal open

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b378994c8333976edf2195063a7e