### PR TITLE
Improve mobile dashboard spacing and modal scroll

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -275,7 +275,7 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-beige-100 dark:bg-[#212121] pt-20 xl:pt-40 pb-8 transition-colors duration-300">
+    <div className="min-h-screen bg-beige-100 dark:bg-[#212121] pt-12 xl:pt-40 pb-8 transition-colors duration-300">
       {/* Fixed Add Trip Button fine-tuned positioning - Only show for authorized users */}
       {canCreateTrips && (
         <div className="fixed left-[calc(50%-400px-160px)] top-[260px] xl:top-[260px] z-30 hidden xl:block">
@@ -291,7 +291,7 @@ export default function Dashboard() {
         </div>
       )}
 
-      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-5 xl:pt-0 mt-[90px] xl:mt-0">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8 pt-5 xl:pt-0 mt-[60px] xl:mt-0">
         
         {/* Debug info - temporary */}
         <AuthDebug />

--- a/src/components/dashboard/QuickViewModal.tsx
+++ b/src/components/dashboard/QuickViewModal.tsx
@@ -286,7 +286,7 @@ export default function QuickViewModal({ trip, isOpen, onClose, onSave, readOnly
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-black dark:bg-opacity-70 flex items-center justify-center z-50 p-2 md:p-4">
+    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-black dark:bg-opacity-70 flex items-start md:items-center justify-center z-50 p-2 md:p-4 overflow-y-auto">
       <div className={`bg-white dark:bg-[#1a1a1a] rounded-xl shadow-xl border border-pearl-200 dark:border-[#2a2a2a] flex flex-col ${
         getScheduleWidth()
       }`}>
@@ -388,7 +388,7 @@ export default function QuickViewModal({ trip, isOpen, onClose, onSave, readOnly
             )}
             
             {/* Tab Content Area */}
-            <div className="flex-1 overflow-y-auto p-3 md:p-6" ref={(el) => {
+            <div className="flex-1 overflow-y-auto p-3 md:p-6 touch-pan-y" ref={(el) => {
               // Auto-scroll to top when Schedule tab becomes active
               if (activeTab === 'schedule' && el) {
                 el.scrollTop = 0


### PR DESCRIPTION
## Summary
- Reduce dashboard top padding and margin on mobile for tighter layout
- Allow scrolling in QuickViewModal on mobile by adjusting overlay and touch behavior

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b3b62045c88333b7423aa6b904f03a