### PR TITLE
Make modals full screen on mobile

### DIFF
--- a/src/components/calendar/ActivityEditor.tsx
+++ b/src/components/calendar/ActivityEditor.tsx
@@ -157,8 +157,8 @@ export function ActivityEditor({
   if (!isOpen) return null
 
   return (
-    <div 
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-0 sm:p-4"
       role="dialog"
       aria-modal="true"
       aria-labelledby="activity-editor-title"
@@ -166,7 +166,7 @@ export function ActivityEditor({
         if (e.target === e.currentTarget) onClose()
       }}
     >
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl max-w-2xl w-full max-h-[90vh] overflow-hidden">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="px-6 py-4 bg-emerald-800 dark:bg-emerald-900 border-b border-emerald-700">
           <div className="flex items-center justify-between">

--- a/src/components/companies/AddCompanyModal.tsx
+++ b/src/components/companies/AddCompanyModal.tsx
@@ -157,8 +157,8 @@ export default function AddCompanyModal({ isOpen, onClose, companyType }: AddCom
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] overflow-y-auto flex flex-col">
         {/* Header */}
         <div className="sticky top-0 bg-golden-400 dark:bg-[#09261d] text-white dark:text-golden-400 px-6 py-4 border-b border-pearl-200 dark:border-[#0a2e21] flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">

--- a/src/components/companies/CompanyLocationsManager.tsx
+++ b/src/components/companies/CompanyLocationsManager.tsx
@@ -339,8 +339,8 @@ function LocationFormModal({
   }
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl max-w-2xl w-full max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="sticky top-0 bg-golden-400 dark:bg-[#09261d] text-white dark:text-golden-400 px-6 py-4 border-b border-pearl-200 dark:border-[#0a2e21] flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">

--- a/src/components/companies/LabCreationModal.tsx
+++ b/src/components/companies/LabCreationModal.tsx
@@ -149,8 +149,8 @@ export default function LabCreationModal({ isOpen, onClose, onLabCreated }: LabC
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl max-w-3xl w-full max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl w-full h-full sm:max-w-3xl sm:h-auto sm:max-h-[90vh] overflow-y-auto">
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] text-white dark:text-golden-400 px-6 py-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">

--- a/src/components/companies/QuickTripPlanningModal.tsx
+++ b/src/components/companies/QuickTripPlanningModal.tsx
@@ -281,8 +281,8 @@ export default function QuickTripPlanningModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg shadow-2xl w-full max-w-6xl max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-0 sm:p-4 z-50">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg shadow-2xl w-full h-full sm:max-w-6xl sm:h-auto sm:max-h-[90vh] overflow-hidden flex flex-col">
         {/* Header */}
         <div className="bg-gradient-to-r from-emerald-600 to-emerald-700 p-6 text-white">
           <div className="flex items-center justify-between">

--- a/src/components/companies/UnifiedCompanyCreationModal.tsx
+++ b/src/components/companies/UnifiedCompanyCreationModal.tsx
@@ -295,8 +295,8 @@ export default function UnifiedCompanyCreationModal({
   if (!isOpen) return null
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className={`bg-white dark:bg-[#1a1a1a] rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl max-w-4xl w-full max-h-[95vh] ${currentStep === CreationStep.SEARCH ? 'overflow-visible' : 'overflow-hidden'}`}>
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className={`bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg border border-pearl-200 dark:border-[#2a2a2a] shadow-xl w-full h-full sm:max-w-4xl sm:h-auto sm:max-h-[95vh] ${currentStep === CreationStep.SEARCH ? 'overflow-visible' : 'overflow-hidden'} flex flex-col`}>
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] text-white dark:text-golden-400 px-6 py-4 flex items-center justify-between">
           <h2 className="text-xl font-semibold flex items-center gap-2">

--- a/src/components/companies/tabs/CompanyLocationsTab.tsx
+++ b/src/components/companies/tabs/CompanyLocationsTab.tsx
@@ -402,10 +402,10 @@ export default function CompanyLocationsTab({ companyId, editMode }: CompanyLoca
       {/* Add/Edit Location Form Modal */}
       {isFormOpen && (
         <div className="fixed inset-0 z-50 overflow-y-auto">
-          <div className="flex min-h-screen items-center justify-center p-4">
+          <div className="flex min-h-screen items-center justify-center p-0 sm:p-4">
             <div className="fixed inset-0 bg-black/50" onClick={() => setIsFormOpen(false)} />
-            
-            <div className="relative bg-white dark:bg-[#1a1a1a] rounded-lg shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full max-w-4xl max-h-[90vh] overflow-y-auto">
+
+            <div className="relative bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full h-full sm:max-w-4xl sm:h-auto sm:max-h-[90vh] overflow-y-auto">
               <div className="bg-golden-400 dark:bg-[#09261d] px-6 py-4 border-b border-pearl-200 dark:border-[#0a2e21] rounded-t-lg">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-golden-400">
                   {editingLocation ? 'Edit Location' : 'Add New Location'}

--- a/src/components/companies/tabs/CompanyStaffTab.tsx
+++ b/src/components/companies/tabs/CompanyStaffTab.tsx
@@ -441,10 +441,10 @@ export default function CompanyStaffTab({ companyId, editMode }: CompanyStaffTab
       {/* Add/Edit Staff Form Modal */}
       {isFormOpen && (
         <div className="fixed inset-0 z-50 overflow-y-auto">
-          <div className="flex min-h-screen items-center justify-center p-4">
+          <div className="flex min-h-screen items-center justify-center p-0 sm:p-4">
             <div className="fixed inset-0 bg-black/50" onClick={() => setIsFormOpen(false)} />
-            
-            <div className="relative bg-white dark:bg-[#1a1a1a] rounded-lg shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+
+            <div className="relative bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] overflow-y-auto">
               <div className="bg-golden-400 dark:bg-[#09261d] px-6 py-4 border-b border-pearl-200 dark:border-[#0a2e21] rounded-t-lg">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-golden-400">
                   {editingStaff ? 'Edit Staff Member' : 'Add New Staff Member'}

--- a/src/components/dashboard/QuickViewModal.tsx
+++ b/src/components/dashboard/QuickViewModal.tsx
@@ -263,7 +263,7 @@ export default function QuickViewModal({ trip, isOpen, onClose, onSave, readOnly
 
   // Calculate flexible width based on trip duration for schedule mode
   const getScheduleWidth = () => {
-    if (!isEditing || activeTab !== 'schedule') return 'max-w-5xl w-full max-h-[90vh]'
+    if (!isEditing || activeTab !== 'schedule') return 'w-full h-full sm:max-w-5xl sm:max-h-[90vh]'
     
     const days = calculateDuration(localTrip.startDate, localTrip.endDate)
     
@@ -282,11 +282,11 @@ export default function QuickViewModal({ trip, isOpen, onClose, onSave, readOnly
       widthClass = 'max-w-[92vw]' // Maximum for 8+ days + padding
     }
     
-    return `w-full ${widthClass} h-[95vh]`
+    return `w-full h-full sm:h-[95vh] ${widthClass}`
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-black dark:bg-opacity-70 flex items-start md:items-center justify-center z-50 p-2 md:p-4 overflow-y-auto">
+    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-black dark:bg-opacity-70 flex items-start md:items-center justify-center z-50 p-0 sm:p-2 md:p-4 overflow-y-auto">
       <div className={`bg-white dark:bg-[#1a1a1a] rounded-xl shadow-xl border border-pearl-200 dark:border-[#2a2a2a] flex flex-col ${
         getScheduleWidth()
       }`}>

--- a/src/components/dashboard/tabs/ScheduleTab.tsx
+++ b/src/components/dashboard/tabs/ScheduleTab.tsx
@@ -339,7 +339,7 @@ export function ScheduleTab({
       {/* Activity Editor Modal */}
       {showActivityEditor && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className="bg-white dark:bg-[#1a1a1a] rounded-lg p-6 w-full max-w-2xl mx-4 max-h-[90vh] overflow-y-auto">
+          <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg p-6 w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] mx-0 sm:mx-4 overflow-y-auto">
             <div className="flex items-center justify-between mb-4">
               <h3 className="text-lg font-semibold text-gray-900 dark:text-golden-400">
                 {editingActivity ? 'Edit Activity' : 'Add Activity'}

--- a/src/components/participants/AddParticipantsDialog.tsx
+++ b/src/components/participants/AddParticipantsDialog.tsx
@@ -199,8 +199,8 @@ export function AddParticipantsDialog({
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg shadow-xl border border-pearl-200 dark:border-[#2a2a2a] max-w-4xl w-full max-h-[90vh] flex flex-col">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full h-full sm:max-w-4xl sm:h-auto sm:max-h-[90vh] flex flex-col overflow-auto sm:overflow-hidden">
         {/* Header */}
         <div className="flex items-center justify-between p-6 border-b border-gray-200 dark:border-[#2a2a2a]">
           <div>

--- a/src/components/participants/CompanySelectionModal.tsx
+++ b/src/components/participants/CompanySelectionModal.tsx
@@ -299,7 +299,7 @@ export function CompanySelectionModal({ isOpen, onClose, tripId, onInvitationSen
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white dark:bg-[#1a1a1a] border border-pearl-200 dark:border-[#2a2a2a] shadow-xl rounded-lg max-w-6xl w-full mx-4 max-h-[90vh] overflow-hidden">
+      <div className="bg-white dark:bg-[#1a1a1a] border border-pearl-200 dark:border-[#2a2a2a] shadow-xl rounded-none sm:rounded-lg w-full h-full sm:max-w-6xl sm:h-auto sm:max-h-[90vh] mx-0 sm:mx-4 flex flex-col overflow-auto sm:overflow-hidden">
         
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] text-white dark:text-golden-400 px-6 py-4 border-b border-pearl-200 dark:border-[#0a2e21] flex justify-between items-center">
@@ -313,7 +313,7 @@ export function CompanySelectionModal({ isOpen, onClose, tripId, onInvitationSen
         </div>
 
         {/* Content */}
-        <div className="bg-white dark:bg-[#1a1a1a] overflow-hidden">
+        <div className="flex-1 bg-white dark:bg-[#1a1a1a] overflow-hidden flex flex-col">
           {error && (
             <div className="flex items-center gap-2 p-3 bg-red-50 dark:bg-red-900/20 border-b border-red-200 dark:border-red-800">
               <AlertCircle className="w-4 h-4 text-red-600 dark:text-red-400 flex-shrink-0" />
@@ -334,12 +334,12 @@ export function CompanySelectionModal({ isOpen, onClose, tripId, onInvitationSen
               </p>
             </div>
           ) : loading ? (
-            <div className="text-center py-12">
+            <div className="text-center py-12 flex-1">
               <div className="animate-spin rounded-full h-8 w-8 border-2 border-emerald-600 border-t-transparent mx-auto mb-4"></div>
               <p className="text-gray-500 dark:text-gray-400">Loading companies...</p>
             </div>
           ) : (
-            <div className="overflow-y-auto max-h-[calc(90vh-120px)]">
+            <div className="flex-1 overflow-y-auto">
               {/* Companies Table */}
               <div className="border border-gray-200 dark:border-[#2a2a2a] rounded-lg overflow-hidden">
                 {companies.length > 0 ? (

--- a/src/components/participants/EnhancedGuestInvitationModal.tsx
+++ b/src/components/participants/EnhancedGuestInvitationModal.tsx
@@ -241,7 +241,7 @@ export function EnhancedGuestInvitationModal({ isOpen, onClose, tripId, onInvita
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50">
-      <div className="bg-white dark:bg-[#1a1a1a] border border-pearl-200 dark:border-[#2a2a2a] shadow-xl rounded-lg max-w-2xl w-full mx-4 max-h-[90vh] overflow-hidden">
+      <div className="bg-white dark:bg-[#1a1a1a] border border-pearl-200 dark:border-[#2a2a2a] shadow-xl rounded-none sm:rounded-lg w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] mx-0 sm:mx-4 flex flex-col overflow-auto sm:overflow-hidden">
         
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] text-white dark:text-golden-400 px-6 py-4 border-b border-pearl-200 dark:border-[#0a2e21] flex justify-between items-center">
@@ -256,7 +256,7 @@ export function EnhancedGuestInvitationModal({ isOpen, onClose, tripId, onInvita
         </div>
 
         {/* Content */}
-        <div className="p-6 bg-white dark:bg-[#1a1a1a] overflow-y-auto max-h-[calc(90vh-120px)]">
+        <div className="flex-1 p-6 bg-white dark:bg-[#1a1a1a] overflow-y-auto">
           {success ? (
             <div className="text-center py-8">
               <div className="w-12 h-12 bg-green-100 dark:bg-green-900 rounded-full flex items-center justify-center mx-auto mb-4">

--- a/src/components/trips/CompanyCreationModal.tsx
+++ b/src/components/trips/CompanyCreationModal.tsx
@@ -103,8 +103,8 @@ export default function CompanyCreationModal({ isOpen, onClose, onCompanyCreated
   const canSubmit = formData.name.trim().length > 0
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-xl shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full max-w-2xl max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-xl shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] px-6 py-4 flex items-center justify-between">
           <div className="flex items-center space-x-3">

--- a/src/components/trips/MeetingAgendaStep.tsx
+++ b/src/components/trips/MeetingAgendaStep.tsx
@@ -438,8 +438,8 @@ const EventModal: React.FC<{
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-lg border border-gray-200 dark:border-[#2a2a2a] w-full max-w-2xl max-h-[90vh] overflow-y-auto">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-lg border border-gray-200 dark:border-[#2a2a2a] w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] overflow-y-auto">
         <div className="p-6">
           <div className="flex items-center justify-between mb-6">
             <h3 className="text-lg font-medium text-gray-900 dark:text-white">

--- a/src/components/trips/UserCreationModal.tsx
+++ b/src/components/trips/UserCreationModal.tsx
@@ -89,8 +89,8 @@ export default function UserCreationModal({
   const selectedCompany = availableCompanies.find(c => c.id === formData.companyId)
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white dark:bg-[#1a1a1a] rounded-xl shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full max-w-lg max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-xl shadow-xl border border-pearl-200 dark:border-[#2a2a2a] w-full h-full sm:max-w-lg sm:h-auto sm:max-h-[90vh] flex flex-col overflow-auto sm:overflow-hidden">
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] px-6 py-4 flex items-center justify-between">
           <div className="flex items-center space-x-3">

--- a/src/components/user/UserPanel.tsx
+++ b/src/components/user/UserPanel.tsx
@@ -150,13 +150,13 @@ const UserPanel: React.FC<UserPanelProps> = ({
       />
       
       {/* Panel */}
-      <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-        <div 
+      <div className="fixed inset-0 z-50 flex items-center justify-center p-0 sm:p-4">
+        <div
           className={cn(
-            "relative bg-white dark:bg-[#1a1a1a] rounded-xl shadow-2xl",
+            "relative bg-white dark:bg-[#1a1a1a] rounded-none sm:rounded-xl shadow-2xl",
             "border border-pearl-200 dark:border-[#2a2a2a]",
-            "max-w-2xl w-full max-h-[90vh] overflow-hidden",
-            "transform transition-all duration-200",
+            "w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] overflow-auto sm:overflow-hidden",
+            "transform transition-all duration-200 flex flex-col",
             isOpen ? "scale-100 opacity-100" : "scale-95 opacity-0"
           )}
         >
@@ -206,7 +206,7 @@ const UserPanel: React.FC<UserPanelProps> = ({
           </div>
 
           {/* Content */}
-          <div className="p-6 overflow-y-auto max-h-[calc(90vh-180px)]">
+          <div className="flex-1 p-6 overflow-y-auto">
             {activeTab === 'profile' && (
               <div className="space-y-6">
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-golden-400">Profile Information</h3>

--- a/src/components/users/InviteUserModal.tsx
+++ b/src/components/users/InviteUserModal.tsx
@@ -97,8 +97,8 @@ export default function InviteUserModal({ currentUser, permissions, onClose, onI
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg max-w-2xl w-full max-h-[90vh] overflow-hidden">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-0 sm:p-4">
+      <div className="bg-white rounded-none sm:rounded-lg w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] flex flex-col overflow-auto sm:overflow-hidden">
         {/* Header */}
         <div className="px-6 py-4 border-b border-gray-200">
           <div className="flex items-center justify-between">
@@ -141,7 +141,7 @@ export default function InviteUserModal({ currentUser, permissions, onClose, onI
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit} className="p-6 overflow-y-auto max-h-[calc(90vh-10rem)]">
+        <form onSubmit={handleSubmit} className="flex-1 p-6 overflow-y-auto">
           <div className="space-y-6">
             {inviteMode === 'single' ? (
               <>

--- a/src/components/users/UserEditModal.tsx
+++ b/src/components/users/UserEditModal.tsx
@@ -127,9 +127,9 @@ export default function UserEditModal({ user, permissions, onClose, onSave }: Us
   }
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-0 sm:p-4">
       {/* Full width on mobile, constrained on larger screens */}
-      <div className="bg-white dark:bg-[#1a1a1a] border border-pearl-200 dark:border-[#2a2a2a] shadow-xl rounded-lg w-full max-w-full sm:max-w-2xl max-h-[90vh] overflow-hidden">
+      <div className="bg-white dark:bg-[#1a1a1a] border border-pearl-200 dark:border-[#2a2a2a] shadow-xl rounded-none sm:rounded-lg w-full h-full sm:max-w-2xl sm:h-auto sm:max-h-[90vh] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="px-6 py-4 bg-golden-400 dark:bg-[#09261d] border-b border-pearl-200 dark:border-[#0a2e21] flex items-center justify-between">
           <h2 className="text-lg font-semibold text-white dark:text-golden-400">Edit User</h2>
@@ -143,7 +143,7 @@ export default function UserEditModal({ user, permissions, onClose, onSave }: Us
 
         {/* Form */}
         {/* Responsive padding so modal fits on small devices */}
-        <form onSubmit={handleSubmit} className="p-4 sm:p-6 bg-white dark:bg-[#1a1a1a] overflow-y-auto max-h-[calc(90vh-8rem)]">
+        <form onSubmit={handleSubmit} className="flex-1 p-4 sm:p-6 bg-white dark:bg-[#1a1a1a] overflow-y-auto">
           <div className="space-y-6">
             {/* Basic Information */}
             <div>

--- a/src/components/users/UserManagementModal.tsx
+++ b/src/components/users/UserManagementModal.tsx
@@ -48,8 +48,8 @@ export default function UserManagementModal({ isOpen, onClose }: UserManagementM
   const showTeamTab = permissions.canViewCompanyUsers || permissions.canViewAllUsers
 
   const modalContent = (
-    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-black dark:bg-opacity-70 flex items-center justify-center z-[9999] p-2 md:p-4">
-      <div className="bg-[#EDE4D3] dark:bg-[#1a1a1a] rounded-lg shadow-xl max-w-5xl w-full max-h-[95vh] md:max-h-[90vh] overflow-y-auto border border-pearl-200 dark:border-[#2a2a2a]">
+    <div className="fixed inset-0 bg-black bg-opacity-50 dark:bg-black dark:bg-opacity-70 flex items-center justify-center z-[9999] p-0 sm:p-2 md:p-4">
+      <div className="bg-[#EDE4D3] dark:bg-[#1a1a1a] rounded-none sm:rounded-lg shadow-xl w-full h-full sm:max-w-5xl sm:h-auto sm:max-h-[90vh] border border-pearl-200 dark:border-[#2a2a2a] flex flex-col overflow-hidden">
         {/* Header */}
         <div className="bg-golden-400 dark:bg-[#09261d] px-3 md:px-6 py-4 relative flex items-center justify-between border-b border-pearl-200 dark:border-[#0a2e21]">
           <div className="flex items-center justify-between w-full">
@@ -99,7 +99,7 @@ export default function UserManagementModal({ isOpen, onClose }: UserManagementM
         </div>
 
         {/* Content */}
-        <div className="p-3 md:p-6 space-y-6">
+        <div className="flex-1 overflow-y-auto p-3 md:p-6 space-y-6">
           {activeTab === 'profile' ? (
             <div className="bg-[#F5F1E8] dark:bg-[#1a1a1a] rounded-lg border border-pearl-200 dark:border-[#2a2a2a] p-4">
               <UserProfileSection user={user} isOwnProfile={true} onUpdate={handleProfileUpdate} />


### PR DESCRIPTION
## Summary
- Expand modals to full-screen layout on small screens for better mobile usability
- Adjust internal scrolling to use flex containers and overflow handling

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Error: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68b441421db48333a3f0ee50cf6472c1