### PR TITLE
Fix registration flow to store JWT token

### DIFF
--- a/src/app/api/auth/register-invitation/route.ts
+++ b/src/app/api/auth/register-invitation/route.ts
@@ -181,6 +181,7 @@ export async function POST(request: NextRequest) {
         role: newUser.role,
         company_name: invitation.companies.fantasy_name || invitation.companies.name
       },
+      sessionToken,
       // Include session info if sign-in was successful
       session: signInData?.session || null
     })

--- a/src/app/auth/register/page.tsx
+++ b/src/app/auth/register/page.tsx
@@ -106,7 +106,13 @@ function RegisterContent() {
       }
 
       console.log('Account created successfully')
-      
+
+      // Store JWT session token for API calls before setting Supabase session
+      if (result.sessionToken) {
+        localStorage.setItem('auth-token', result.sessionToken)
+        console.log('Stored JWT session token from registration')
+      }
+
       // If we got a session, set it in Supabase client for immediate auth state
       if (result.session) {
         try {


### PR DESCRIPTION
## Summary
- Return JWT session token from invitation registration endpoint
- Persist the token on the client before setting Supabase session to keep API calls authenticated

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: Error: supabaseUrl is required.)

------
https://chatgpt.com/codex/tasks/task_e_68b7189cdb648333ba001fc3b3502359