### PR TITLE
feat: notify stakeholders on trip updates

### DIFF
--- a/src/lib/send-trip-notification.ts
+++ b/src/lib/send-trip-notification.ts
@@ -1,0 +1,84 @@
+import { Resend } from 'resend'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import readline from 'readline'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
+
+interface Params {
+  type: 'create' | 'cancel'
+  tripId: string
+}
+
+function formatDate(date: string | null): string {
+  return date ? new Date(date).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }) : ''
+}
+
+async function promptForCancellation(): Promise<boolean> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout })
+  return new Promise(resolve => {
+    rl.question('Send cancellation email to all stakeholders? (y/N) ', answer => {
+      rl.close()
+      resolve(/^y(es)?$/i.test(answer.trim()))
+    })
+  })
+}
+
+export async function sendTripNotification({ type, tripId }: Params) {
+  const supabase = createSupabaseServiceClient()
+  const { data: trip, error } = await supabase
+    .from('trips')
+    .select(`id, name, start_date, end_date, trip_participants (
+        role,
+        users:users!trip_participants_user_id_fkey(email),
+        guest_email
+      )`)
+    .eq('id', tripId)
+    .single()
+
+  if (error || !trip) {
+    console.error('Failed to load trip for notifications', error)
+    return { success: false }
+  }
+
+  const emails = (trip.trip_participants || [])
+    .map((p: any) => p.users?.email || p.guest_email)
+    .filter(Boolean)
+
+  if (emails.length === 0) {
+    console.log('No stakeholder emails found for trip', tripId)
+    return { success: false }
+  }
+
+  if (type === 'cancel') {
+    const confirmed = await promptForCancellation()
+    if (!confirmed) {
+      console.log('Cancellation notification not sent')
+      return { success: false }
+    }
+  }
+
+  const subject = type === 'create'
+    ? `New Trip Created: ${trip.name}`
+    : `Trip Cancelled: ${trip.name}`
+
+  const html = type === 'create'
+    ? `<p>A new trip has been created.</p><p><strong>${trip.name}</strong></p><p>${formatDate(trip.start_date)} - ${formatDate(trip.end_date)}</p>`
+    : `<p>The trip <strong>${trip.name}</strong> scheduled for ${formatDate(trip.start_date)} - ${formatDate(trip.end_date)} has been cancelled.</p>`
+
+  try {
+    await resend.emails.send({
+      from: 'Wolthers Travel Platform <noreply@trips.wolthers.com>',
+      to: emails,
+      subject,
+      html,
+    })
+    return { success: true }
+  } catch (err) {
+    console.error('Error sending trip notification', err)
+    return { success: false }
+  }
+}

--- a/src/lib/trip-actions.ts
+++ b/src/lib/trip-actions.ts
@@ -2,6 +2,7 @@
 
 import { revalidateTag } from 'next/cache'
 import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { sendTripNotification } from '@/lib/send-trip-notification'
 
 // Finalize or create a trip and revalidate caches
 export async function createTrip(tripId: string, userId: string) {
@@ -20,6 +21,7 @@ export async function createTrip(tripId: string, userId: string) {
 
   revalidateTag('trips')
   revalidateTag(`trips:user:${userId}`)
+  await sendTripNotification({ type: 'create', tripId })
   return data
 }
 
@@ -37,5 +39,6 @@ export async function cancelTrip(tripId: string, userId: string) {
 
   revalidateTag('trips')
   revalidateTag(`trips:user:${userId}`)
+  await sendTripNotification({ type: 'cancel', tripId })
   return { success: true }
 }


### PR DESCRIPTION
## Summary
- add `sendTripNotification` helper to email trip stakeholders via Resend
- send notification on trip creation and optional cancellation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build` (fails: supabaseUrl is required)

------
https://chatgpt.com/codex/tasks/task_e_68becbd7e2648333bd62929fbe426659

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sends email notifications to all trip stakeholders when a trip is created or cancelled, including trip name and dates.
  * Prevents sending when no recipients are available and surfaces a clear failure.
* **Changes**
  * Trip creation and cancellation now wait for notification delivery; users may experience a brief delay or see an error if sending fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->