### PR TITLE
feat: invite staff by email during trip creation

### DIFF
--- a/src/app/api/trips/[id]/staff/route.ts
+++ b/src/app/api/trips/[id]/staff/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createServerSupabaseClient } from '@/lib/supabase-server'
+import { EmailService } from '@/lib/email-service'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { email } = await request.json()
+    if (!email) {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    }
+
+    const { id } = await params
+    const supabase = createServerSupabaseClient()
+
+    // Fetch trip for email details
+    const { data: trip, error: tripError } = await supabase
+      .from('trips')
+      .select('id, name, start_date, end_date')
+      .eq('id', id)
+      .single()
+
+    if (tripError || !trip) {
+      return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
+    }
+
+    // Check if user exists
+    const { data: existingUser } = await supabase
+      .from('users')
+      .select('*')
+      .eq('email', email)
+      .single()
+      .throwOnError(false)
+
+    let user = existingUser
+
+    if (!user) {
+      // Create invited user
+      const { data: newUser, error: createError } = await supabase
+        .from('users')
+        .insert({ email, status: 'invited' })
+        .select()
+        .single()
+
+      if (createError || !newUser) {
+        return NextResponse.json({ error: 'Failed to create user' }, { status: 500 })
+      }
+      user = newUser
+
+      // Send invitation email
+      const inviteLink = `https://trips.wolthers.com/auth/register?email=${encodeURIComponent(email)}&tripId=${id}`
+      await EmailService.sendTripInviteEmail({
+        email,
+        tripName: trip.name,
+        startDate: trip.start_date,
+        endDate: trip.end_date,
+        inviteLink
+      })
+    }
+
+    // Link user to trip
+    const { error: linkError } = await supabase
+      .from('trip_staff')
+      .insert({ trip_id: id, user_id: user.id })
+
+    if (linkError) {
+      return NextResponse.json({ error: 'Failed to link staff to trip' }, { status: 500 })
+    }
+
+    return NextResponse.json({ user })
+  } catch (error) {
+    console.error('Error adding staff to trip', error)
+    return NextResponse.json({ error: 'Server error' }, { status: 500 })
+  }
+}

--- a/src/components/ui/MultiSelectSearch.tsx
+++ b/src/components/ui/MultiSelectSearch.tsx
@@ -19,6 +19,8 @@ interface MultiSelectSearchProps {
   className?: string
   disabled?: boolean
   maxDisplayItems?: number
+  allowCustomInput?: boolean
+  onCreateOption?: (input: string) => void | Promise<void>
 }
 
 export default function MultiSelectSearch({
@@ -30,7 +32,9 @@ export default function MultiSelectSearch({
   emptyMessage = "No options found",
   className,
   disabled = false,
-  maxDisplayItems = 5
+  maxDisplayItems = 5,
+  allowCustomInput = false,
+  onCreateOption
 }: MultiSelectSearchProps) {
   const [isOpen, setIsOpen] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
@@ -169,9 +173,25 @@ export default function MultiSelectSearch({
           {/* Options List */}
           <div className="max-h-[400px] overflow-y-auto">
             {filteredOptions.length === 0 ? (
-              <div className="px-3 py-4 text-center text-gray-500 dark:text-gray-400 text-sm">
-                {emptyMessage}
-              </div>
+              allowCustomInput && searchTerm ? (
+                <button
+                  type="button"
+                  onClick={async () => {
+                    if (onCreateOption) {
+                      await onCreateOption(searchTerm)
+                    }
+                    setSearchTerm('')
+                    setIsOpen(false)
+                  }}
+                  className="w-full px-3 py-2 text-left hover:bg-gray-50 dark:hover:bg-[#2a2a2a] text-sm text-blue-600 dark:text-blue-400"
+                >
+                  Add "{searchTerm}"
+                </button>
+              ) : (
+                <div className="px-3 py-4 text-center text-gray-500 dark:text-gray-400 text-sm">
+                  {emptyMessage}
+                </div>
+              )
             ) : (
               filteredOptions.map(option => {
                 const isSelected = value.includes(option.id)

--- a/src/lib/email-service.ts
+++ b/src/lib/email-service.ts
@@ -33,6 +33,14 @@ export interface TripCancellationEmailData {
   originalEndDate: string
 }
 
+export interface TripInviteEmailData {
+  email: string
+  tripName: string
+  startDate?: string | null
+  endDate?: string | null
+  inviteLink: string
+}
+
 export class EmailService {
   private static async sendEmail(to: string, subject: string, html: string) {
     try {
@@ -334,6 +342,33 @@ export class EmailService {
       return { success: false, error: 'Failed to send trip cancellation email' }
     }
   }
+
+  static async sendTripInviteEmail(data: TripInviteEmailData): Promise<{ success: boolean; messageId?: string; error?: string }> {
+    try {
+      const subject = `You’ve been invited to join ${data.tripName}`
+      const dateInfo = data.startDate && data.endDate ? `<p>${data.startDate} - ${data.endDate}</p>` : ''
+      const html = `
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+          <meta charset="UTF-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1.0">
+          <title>Trip Invitation</title>
+        </head>
+        <body>
+          <p>You have been invited to join <strong>${data.tripName}</strong>.</p>
+          ${dateInfo}
+          <p><a href="${data.inviteLink}">Create your account</a> to view the trip details.</p>
+        </body>
+        </html>
+      `
+      return await this.sendEmail(data.email, subject, html)
+    } catch (error) {
+      console.error('[EMAIL SERVICE] Error sending trip invite email:', error)
+      return { success: false, error: 'Failed to send trip invite email' }
+    }
+  }
 }
 
 export default EmailService
+


### PR DESCRIPTION
## Summary
- allow custom staff email entry in CreateTrip team step
- invite email-only staff via API and send Resend invite
- add Resend helper for trip invitations

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68becd25909c8333b9f1bc44321adee9