### PR TITLE
feat: add distance matrix drive calculations

### DIFF
--- a/src/components/dashboard/OutlookCalendar.tsx
+++ b/src/components/dashboard/OutlookCalendar.tsx
@@ -932,8 +932,8 @@ export function OutlookCalendar({
       // Recalculate travel times for both affected dates
       console.log('📋 [Travel Recalc] Recalculating travel times after activity swap...')
       const allActivities = Object.values(activitiesByDate).flat()
-      const updates1 = recalculateTravelTimes(allActivities, activity.id, targetDate, targetTime)
-      const updates2 = recalculateTravelTimes(allActivities, targetSlotActivity.id, item.originalDate, item.originalTime)
+      const updates1 = await recalculateTravelTimes(allActivities, activity.id, targetDate, targetTime)
+      const updates2 = await recalculateTravelTimes(allActivities, targetSlotActivity.id, item.originalDate, item.originalTime)
       
       // Apply travel time updates
       await Promise.all([...updates1, ...updates2].map(async (update) => {
@@ -956,7 +956,7 @@ export function OutlookCalendar({
       // Recalculate travel times for the target date
       console.log('📋 [Travel Recalc] Recalculating travel times after activity move...')
       const allActivities = Object.values(activitiesByDate).flat()
-      const updates = recalculateTravelTimes(allActivities, activity.id, targetDate, targetTime)
+      const updates = await recalculateTravelTimes(allActivities, activity.id, targetDate, targetTime)
       
       // Apply travel time updates
       await Promise.all(updates.map(async (update) => {

--- a/src/hooks/useActivityManager.ts
+++ b/src/hooks/useActivityManager.ts
@@ -54,6 +54,8 @@ export interface Activity {
   company_id?: string
   company_name?: string
   is_parallel_allowed?: boolean
+  branch_id?: string
+  visibleToCompanies?: string[]
   // Participant information (populated from join)
   participants?: ActivityParticipant[]
   created_at?: string
@@ -76,6 +78,8 @@ export interface ActivityFormData {
   currency?: 'BRL' | 'USD' | 'EUR' | 'GBP' | 'DKK'
   is_confirmed?: boolean
   notes?: string
+  branch_id?: string
+  visibleToCompanies?: string[]
 }
 
 export interface ActivityStats {

--- a/src/lib/distance-matrix.ts
+++ b/src/lib/distance-matrix.ts
@@ -1,0 +1,47 @@
+interface CacheEntry {
+  expires: number
+  distance: number
+  duration: number
+}
+
+const cache = new Map<string, CacheEntry>()
+const TTL = 5 * 60 * 1000 // 5 minutes
+
+function cacheKey(origin: string, destination: string) {
+  return `${origin}__${destination}`
+}
+
+export async function getDriveDuration(origin: string, destination: string) {
+  const key = cacheKey(origin, destination)
+  const now = Date.now()
+  const cached = cache.get(key)
+  if (cached && cached.expires > now) {
+    return { distance: cached.distance, duration: cached.duration }
+  }
+
+  const apiKey = process.env.GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+  if (!apiKey) {
+    console.warn('Google Maps API key not configured')
+    return { distance: 0, duration: 0 }
+  }
+
+  const url = `https://maps.googleapis.com/maps/api/distancematrix/json?origins=${encodeURIComponent(origin)}&destinations=${encodeURIComponent(destination)}&mode=driving&key=${apiKey}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    console.warn('Distance Matrix request failed', res.status)
+    return { distance: 0, duration: 0 }
+  }
+  const data = await res.json() as any
+  if (data.rows && data.rows[0] && data.rows[0].elements && data.rows[0].elements[0] && data.rows[0].elements[0].status === 'OK') {
+    const element = data.rows[0].elements[0]
+    cache.set(key, {
+      distance: element.distance.value,
+      duration: element.duration.value,
+      expires: now + TTL
+    })
+    return { distance: element.distance.value, duration: element.duration.value }
+  }
+
+  console.warn('Distance Matrix returned no result', data.status)
+  return { distance: 0, duration: 0 }
+}

--- a/src/lib/travel-recalculation.ts
+++ b/src/lib/travel-recalculation.ts
@@ -5,7 +5,8 @@
  * via drag-and-drop, ensuring optimal scheduling and route planning.
  */
 
-import { calculateTravelTime, isSantosArea, isVarginhaArea } from '@/lib/brazilian-locations'
+import { isSantosArea, isVarginhaArea } from '@/lib/brazilian-locations'
+import { getDriveDuration } from '@/lib/distance-matrix'
 
 export interface Activity {
   id: string
@@ -120,12 +121,12 @@ function createTravelActivity(
 /**
  * Recalculate travel times after an activity is moved
  */
-export function recalculateTravelTimes(
+export async function recalculateTravelTimes(
   activities: Activity[],
   movedActivityId: string,
   newDate: string,
   newStartTime: string
-): TravelTimeUpdate[] {
+): Promise<TravelTimeUpdate[]> {
   const updates: TravelTimeUpdate[] = []
   
   // Find the moved activity
@@ -184,8 +185,9 @@ export function recalculateTravelTimes(
     const currentCity = extractCityFromActivity(currentActivity)
     const nextCity = extractCityFromActivity(nextActivity)
     
-    // Calculate travel time
-    const travelHours = calculateTravelTime(currentCity, nextCity)
+    // Calculate travel time using Google Distance Matrix API
+    const { duration } = await getDriveDuration(currentCity, nextCity)
+    const travelHours = duration / 3600
     
     // Only create travel activity if there's actual travel time (> 10 minutes)
     if (travelHours > 0.15) {
@@ -206,7 +208,7 @@ export function recalculateTravelTimes(
       })
     }
   }
-  
+
   return updates
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -161,6 +161,8 @@ export interface Trip {
   parentTripId?: string
   /** Date when trip was branched from parent */
   branchDate?: Date
+  /** Mapping of company IDs to branch IDs */
+  trip_branches?: Record<string, string>
   /** Additional metadata */
   metadata: Record<string, any>
   /** Public access code for guest access */
@@ -244,6 +246,10 @@ export interface Activity {
   confirmationStatus: string
   /** Additional notes */
   notes?: string
+  /** Companies allowed to view this activity */
+  visibleToCompanies?: string[]
+  /** Branch identifier for split itineraries */
+  branchId?: string
   /** External event source information */
   externalSource?: {
     name: string


### PR DESCRIPTION
## Summary
- integrate Google Distance Matrix API with 5-minute cache
- recalculate travel times asynchronously using drive durations
- expose company visibility and branch fields on activities and trips

## Testing
- `npm test`
- `npm run build` *(fails: Creating an optimized production build ... hangs)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2c23b17483339ca9d4c6a56ac992