### PR TITLE
feat: add driver and vehicle assignment step

### DIFF
--- a/src/app/api/trips/drivers/assign/route.ts
+++ b/src/app/api/trips/drivers/assign/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { tripId, userId } = await req.json()
+    if (!tripId || !userId) {
+      return NextResponse.json({ error: 'tripId and userId required' }, { status: 400 })
+    }
+    const supabase = createSupabaseServiceClient()
+    const { data: trip, error: tripError } = await supabase
+      .from('trips')
+      .select('start_date,end_date')
+      .eq('id', tripId)
+      .single()
+    if (tripError || !trip) {
+      return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
+    }
+    await supabase.from('trip_participants').upsert(
+      {
+        trip_id: tripId,
+        user_id: userId,
+        role: 'driver',
+        start_date: trip.start_date,
+        end_date: trip.end_date
+      },
+      { onConflict: 'trip_id,user_id' }
+    )
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('assignDriver error', err)
+    return NextResponse.json({ error: 'Failed to assign driver' }, { status: 500 })
+  }
+}

--- a/src/app/api/trips/drivers/invite/route.ts
+++ b/src/app/api/trips/drivers/invite/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+import { sendTripNotification } from '@/lib/send-trip-notification'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { tripId, name, email } = await req.json()
+    if (!tripId || !email) {
+      return NextResponse.json({ error: 'tripId and email required' }, { status: 400 })
+    }
+    const supabase = createSupabaseServiceClient()
+
+    // Upsert user
+    const { data: existing } = await supabase
+      .from('users')
+      .select('id, full_name, email')
+      .eq('email', email)
+      .single()
+
+    let userId = existing?.id
+    if (!existing) {
+      const { data: created, error: createError } = await supabase
+        .from('users')
+        .insert({ email, full_name: name, role: 'driver', is_active: false })
+        .select('id, full_name, email')
+        .single()
+      if (createError || !created) {
+        return NextResponse.json({ error: 'Failed to create user' }, { status: 500 })
+      }
+      userId = created.id
+    }
+
+    const { data: trip, error: tripError } = await supabase
+      .from('trips')
+      .select('start_date,end_date')
+      .eq('id', tripId)
+      .single()
+    if (tripError || !trip) {
+      return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
+    }
+
+    await supabase.from('trip_participants').upsert(
+      {
+        trip_id: tripId,
+        user_id: userId!,
+        role: 'driver',
+        start_date: trip.start_date,
+        end_date: trip.end_date
+      },
+      { onConflict: 'trip_id,user_id' }
+    )
+
+    await sendTripNotification({ type: 'invited', tripId, email })
+
+    const { data: user } = await supabase
+      .from('users')
+      .select('id, full_name, email')
+      .eq('id', userId)
+      .single()
+
+    return NextResponse.json({ user })
+  } catch (err) {
+    console.error('inviteDriver error', err)
+    return NextResponse.json({ error: 'Failed to invite driver' }, { status: 500 })
+  }
+}

--- a/src/app/api/trips/vehicles/basic-assign/route.ts
+++ b/src/app/api/trips/vehicles/basic-assign/route.ts
@@ -1,0 +1,55 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createSupabaseServiceClient } from '@/lib/supabase-server'
+
+export async function POST(req: NextRequest) {
+  try {
+    const { tripId, vehicleId, rental } = await req.json()
+    if (!tripId || (!vehicleId && !rental)) {
+      return NextResponse.json({ error: 'tripId and vehicleId or rental required' }, { status: 400 })
+    }
+    const supabase = createSupabaseServiceClient()
+    const { data: trip, error: tripError } = await supabase
+      .from('trips')
+      .select('start_date,end_date')
+      .eq('id', tripId)
+      .single()
+    if (tripError || !trip) {
+      return NextResponse.json({ error: 'Trip not found' }, { status: 404 })
+    }
+
+    // Remove previous vehicle assignments for this trip
+    await supabase.from('trip_vehicles').delete().eq('trip_id', tripId)
+
+    const record: any = {
+      trip_id: tripId,
+      start_date: trip.start_date,
+      end_date: trip.end_date,
+      status: 'assigned'
+    }
+    if (vehicleId) {
+      record.vehicle_id = vehicleId
+      record.assignment_type = 'company_vehicle'
+    } else {
+      record.vehicle_id = null
+      record.assignment_type = 'rental_assigned'
+      record.rental_company = rental?.provider || null
+      record.rental_pickup_time = rental?.pickup ? rental.pickup.split('T')[1] : null
+      record.rental_return_time = rental?.dropoff ? rental.dropoff.split('T')[1] : null
+    }
+
+    const { data: inserted, error: insertError } = await supabase
+      .from('trip_vehicles')
+      .insert(record)
+      .select('id, vehicle_id, rental_company, rental_pickup_time, rental_return_time')
+      .single()
+
+    if (insertError) {
+      return NextResponse.json({ error: 'Failed to assign vehicle' }, { status: 500 })
+    }
+
+    return NextResponse.json({ assignment: inserted })
+  } catch (err) {
+    console.error('assignVehicle error', err)
+    return NextResponse.json({ error: 'Failed to assign vehicle' }, { status: 500 })
+  }
+}

--- a/src/components/trips/DriverVehicleStep.tsx
+++ b/src/components/trips/DriverVehicleStep.tsx
@@ -1,0 +1,200 @@
+import React, { useEffect, useState } from 'react'
+import type { TripFormData } from './TripCreationModal'
+import type { User, Vehicle } from '@/types'
+
+interface Props {
+  formData: TripFormData
+  updateFormData: (data: Partial<TripFormData>) => void
+}
+
+export default function DriverVehicleStep({ formData, updateFormData }: Props) {
+  const [drivers, setDrivers] = useState<User[]>([])
+  const [vehicles, setVehicles] = useState<Vehicle[]>([])
+  const [showInvite, setShowInvite] = useState(false)
+  const [inviteName, setInviteName] = useState('')
+  const [inviteEmail, setInviteEmail] = useState('')
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const d = await fetch('/api/users/drivers').then(r => r.json())
+        const v = await fetch('/api/fleet/vehicles').then(r => r.json())
+        setDrivers(d.drivers || [])
+        setVehicles(v.vehicles || [])
+      } catch (err) {
+        console.error('Failed loading drivers/vehicles', err)
+      }
+    }
+    load()
+  }, [])
+
+  const driverOptions: User[] = [...drivers]
+  ;(formData.wolthersStaff || []).forEach(s => {
+    if (!driverOptions.some(d => d.id === s.id)) driverOptions.push(s)
+  })
+
+  const handleDriverChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const id = e.target.value
+    const user = driverOptions.find(u => u.id === id)
+    updateFormData({ drivers: user ? [user] : [] })
+    const tripId = (formData as any).tripId
+    if (tripId && user) {
+      await fetch('/api/trips/drivers/assign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tripId, userId: id })
+      })
+    }
+  }
+
+  const handleInvite = async () => {
+    const name = inviteName.trim()
+    const email = inviteEmail.trim()
+    if (!name || !email) return
+    const tripId = (formData as any).tripId
+    try {
+      const res = await fetch('/api/trips/drivers/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tripId, name, email })
+      })
+      const data = await res.json()
+      if (data.user) {
+        setDrivers(prev => [...prev, data.user])
+        updateFormData({ drivers: [data.user] })
+      }
+    } catch (err) {
+      console.error('Invite driver failed', err)
+    }
+    setShowInvite(false)
+    setInviteName('')
+    setInviteEmail('')
+  }
+
+  const handleVehicleChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const val = e.target.value
+    const tripId = (formData as any).tripId
+    if (val === 'rental') {
+      updateFormData({ selectedVehicleId: undefined, rentalVehicle: { provider: '', pickup: '', dropoff: '' } })
+    } else {
+      updateFormData({ selectedVehicleId: val, rentalVehicle: null })
+      if (tripId) {
+        await fetch('/api/trips/vehicles/basic-assign', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ tripId, vehicleId: val })
+        })
+      }
+    }
+  }
+
+  const handleRentalChange = async (field: 'provider' | 'pickup' | 'dropoff', value: string) => {
+    const rental = { ...(formData.rentalVehicle || { provider: '', pickup: '', dropoff: '' }), [field]: value }
+    updateFormData({ rentalVehicle: rental, selectedVehicleId: undefined })
+    const tripId = (formData as any).tripId
+    if (tripId) {
+      await fetch('/api/trips/vehicles/basic-assign', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ tripId, rental })
+      })
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <div className="space-y-4">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Driver</label>
+        <select
+          value={formData.drivers[0]?.id || ''}
+          onChange={handleDriverChange}
+          className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+        >
+          <option value="">Select driver</option>
+          {driverOptions.map(d => (
+            <option key={d.id} value={d.id}>
+              {d.fullName || d.email}
+            </option>
+          ))}
+        </select>
+        <button
+          type="button"
+          onClick={() => setShowInvite(true)}
+          className="text-sm text-emerald-600 hover:underline"
+        >
+          Invite Driver
+        </button>
+        {showInvite && (
+          <div className="border p-4 rounded-md space-y-2">
+            <input
+              value={inviteName}
+              onChange={e => setInviteName(e.target.value)}
+              placeholder="Name"
+              className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+            />
+            <input
+              value={inviteEmail}
+              onChange={e => setInviteEmail(e.target.value)}
+              placeholder="Email"
+              className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+            />
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleInvite}
+                className="px-3 py-1 bg-emerald-600 text-white rounded"
+              >
+                Send Invite
+              </button>
+              <button
+                type="button"
+                onClick={() => setShowInvite(false)}
+                className="px-3 py-1 border rounded"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+      <div className="space-y-4">
+        <label className="block text-sm font-medium text-gray-700 dark:text-gray-200">Vehicle</label>
+        <select
+          value={formData.selectedVehicleId || (formData.rentalVehicle ? 'rental' : '')}
+          onChange={handleVehicleChange}
+          className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+        >
+          <option value="">Select vehicle</option>
+          {vehicles.map(v => (
+            <option key={v.id} value={v.id}>
+              {v.model} {v.licensePlate ? `(${v.licensePlate})` : ''}
+            </option>
+          ))}
+          <option value="rental">Rental</option>
+        </select>
+        {formData.rentalVehicle && (
+          <div className="space-y-2">
+            <input
+              value={formData.rentalVehicle.provider}
+              onChange={e => handleRentalChange('provider', e.target.value)}
+              placeholder="Provider"
+              className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+            />
+            <input
+              type="datetime-local"
+              value={formData.rentalVehicle.pickup}
+              onChange={e => handleRentalChange('pickup', e.target.value)}
+              className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+            />
+            <input
+              type="datetime-local"
+              value={formData.rentalVehicle.dropoff}
+              onChange={e => handleRentalChange('dropoff', e.target.value)}
+              className="w-full border rounded-md p-2 bg-white dark:bg-gray-800"
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add driver & vehicle step with invite modal
- persist assignments via new API routes
- extend notifications for invited drivers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Missing script "lint")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2e1faa688333aa47c85bfb6debae