### PR TITLE
feat: real-time trip updates and notifications

### DIFF
--- a/src/app/api/trips/drivers/invite/route.ts
+++ b/src/app/api/trips/drivers/invite/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createSupabaseServiceClient } from '@/lib/supabase-server'
 import { sendTripNotification } from '@/lib/send-trip-notification'
+import { revalidateTag } from 'next/cache'
 
 export async function POST(req: NextRequest) {
   try {
@@ -50,7 +51,10 @@ export async function POST(req: NextRequest) {
       { onConflict: 'trip_id,user_id' }
     )
 
-    await sendTripNotification({ type: 'invited', tripId, email })
+    await sendTripNotification({ type: 'invited', tripId, inviteEmail: email })
+
+    revalidateTag('trips')
+    revalidateTag(`trips:user:${userId}`)
 
     const { data: user } = await supabase
       .from('users')

--- a/src/components/trips/DriverVehicleStep.tsx
+++ b/src/components/trips/DriverVehicleStep.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react'
 import type { TripFormData } from './TripCreationModal'
 import type { User, Vehicle } from '@/types'
+import { useRouter } from 'next/navigation'
 
 interface Props {
   formData: TripFormData
@@ -13,6 +14,7 @@ export default function DriverVehicleStep({ formData, updateFormData }: Props) {
   const [showInvite, setShowInvite] = useState(false)
   const [inviteName, setInviteName] = useState('')
   const [inviteEmail, setInviteEmail] = useState('')
+  const router = useRouter()
 
   useEffect(() => {
     const load = async () => {
@@ -62,6 +64,7 @@ export default function DriverVehicleStep({ formData, updateFormData }: Props) {
       if (data.user) {
         setDrivers(prev => [...prev, data.user])
         updateFormData({ drivers: [data.user] })
+        router.refresh()
       }
     } catch (err) {
       console.error('Invite driver failed', err)

--- a/src/lib/trip-actions.ts
+++ b/src/lib/trip-actions.ts
@@ -21,7 +21,7 @@ export async function createTrip(tripId: string, userId: string) {
 
   revalidateTag('trips')
   revalidateTag(`trips:user:${userId}`)
-  await sendTripNotification({ type: 'create', tripId })
+  await sendTripNotification({ type: 'created', tripId })
   return data
 }
 
@@ -39,6 +39,6 @@ export async function cancelTrip(tripId: string, userId: string) {
 
   revalidateTag('trips')
   revalidateTag(`trips:user:${userId}`)
-  await sendTripNotification({ type: 'cancel', tripId })
+  await sendTripNotification({ type: 'cancelled', tripId })
   return { success: true }
 }


### PR DESCRIPTION
## Summary
- send trip notifications for created, cancelled, and invited events using shared invitation template
- refresh trip data when inviting drivers and revalidate caches server-side
- ensure trips dashboard updates via Supabase realtime subscription

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_e_68bf30685c588333a3f60d49fbda7dce

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Driver invitations now use a dedicated email variant with driver-specific subject lines and content. Guest invitations continue with guest-specific messaging.
  - Invitation emails dynamically adjust headers, CTA labels, and info based on recipient type (driver vs guest).

- Improvements
  - The trip page now auto-refreshes after inviting a driver, immediately showing the new driver in the list.
  - Trip lists update more quickly across the app after invitations and changes, improving data freshness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->