### PR TITLE
feat(storage): add safe localStorage helpers

### DIFF
--- a/src/contexts/TripCacheContext.tsx
+++ b/src/contexts/TripCacheContext.tsx
@@ -8,6 +8,7 @@ import { performanceOptimizer, measurePerformance } from '@/lib/cache/performanc
 import type { TripCard } from '@/types'
 import { useAuth } from '@/contexts/AuthContext'
 import { supabase } from '@/lib/supabase-client'
+import { cleanStorageOnBoot } from '@/lib/storage/safeStorage'
 
 // Get environment-appropriate configuration
 const systemConfig = getCacheSystemConfig()
@@ -116,6 +117,10 @@ export function TripCacheProvider({ children }: TripCacheProviderProps) {
   const syncManagerRef = useRef<SyncManager | null>(null)
   const { user } = useAuth()
   const userId = user?.id || 'anonymous'
+
+  useEffect(() => {
+    cleanStorageOnBoot()
+  }, [])
 
   /**
    * Fetch trips from API with authentication

--- a/src/lib/storage/safeStorage.ts
+++ b/src/lib/storage/safeStorage.ts
@@ -1,0 +1,51 @@
+export function safeGet<T = any>(key: string): T | null {
+  if (typeof window === 'undefined') return null
+  try {
+    const raw = window.localStorage.getItem(key)
+    if (raw == null) return null
+    if (typeof raw !== 'string') return null
+    if (raw === '[object Object]') return null
+    return JSON.parse(raw) as T
+  } catch {
+    return null
+  }
+}
+
+export function safeSet(key: string, value: any): void {
+  if (typeof window === 'undefined') return
+  try {
+    const str = typeof value === 'string' ? value : JSON.stringify(value)
+    window.localStorage.setItem(key, str)
+  } catch {
+    // ignore
+  }
+}
+
+const KNOWN_KEYS = [
+  'wolthers-sync-queue',
+  'wolthers-optimized-sync-queue',
+  'wolthers-optimized-sync-queue_metadata',
+  'trip_cache',
+  'user_profile_cache'
+]
+
+export function cleanStorageOnBoot(): void {
+  if (typeof window === 'undefined') return
+  for (const key of KNOWN_KEYS) {
+    try {
+      const raw = window.localStorage.getItem(key)
+      if (raw === null) continue
+      if (raw === '[object Object]' || typeof raw !== 'string') {
+        window.localStorage.removeItem(key)
+        continue
+      }
+      try {
+        JSON.parse(raw)
+      } catch {
+        window.localStorage.removeItem(key)
+      }
+    } catch {
+      // ignore individual key errors
+    }
+  }
+}

--- a/src/lib/supabase-client.ts
+++ b/src/lib/supabase-client.ts
@@ -1,5 +1,6 @@
 import { createClient, SupabaseClient, Session, User } from '@supabase/supabase-js'
 import { Database } from '@/types/database'
+import { safeGet, safeSet } from '@/lib/storage/safeStorage'
 
 // Client-side Supabase client with offline capabilities
 let supabaseClient: SupabaseClient<Database> | null = null
@@ -152,7 +153,7 @@ export function cacheTrips(trips: any[]) {
       timestamp: Date.now(),
       ttl: 24 * 60 * 60 * 1000, // 24 hours
     }
-    localStorage.setItem('trip_cache', JSON.stringify(cacheData))
+    safeSet('trip_cache', cacheData)
   } catch (error) {
     console.warn('Failed to cache trips:', error)
   }
@@ -160,14 +161,12 @@ export function cacheTrips(trips: any[]) {
 
 export function getCachedTrips(): any[] | null {
   if (typeof window === 'undefined') return null
-  
+
   try {
-    const cached = localStorage.getItem('trip_cache')
-    if (!cached) return null
-    
-    const cacheData = JSON.parse(cached)
+    const cacheData = safeGet<any>('trip_cache')
+    if (!cacheData) return null
     const isExpired = Date.now() - cacheData.timestamp > cacheData.ttl
-    
+
     if (isExpired) {
       localStorage.removeItem('trip_cache')
       return null
@@ -189,7 +188,7 @@ export function cacheUserProfile(profile: any) {
       timestamp: Date.now(),
       ttl: 60 * 60 * 1000, // 1 hour
     }
-    localStorage.setItem('user_profile_cache', JSON.stringify(cacheData))
+    safeSet('user_profile_cache', cacheData)
   } catch (error) {
     console.warn('Failed to cache user profile:', error)
   }
@@ -197,12 +196,10 @@ export function cacheUserProfile(profile: any) {
 
 export function getCachedUserProfile(): any | null {
   if (typeof window === 'undefined') return null
-  
+
   try {
-    const cached = localStorage.getItem('user_profile_cache')
-    if (!cached) return null
-    
-    const cacheData = JSON.parse(cached)
+    const cacheData = safeGet<any>('user_profile_cache')
+    if (!cacheData) return null
     const isExpired = Date.now() - cacheData.timestamp > cacheData.ttl
     
     if (isExpired) {

--- a/src/lib/sync/OptimizedQueueManager.ts
+++ b/src/lib/sync/OptimizedQueueManager.ts
@@ -8,6 +8,7 @@
 
 import { QueuedOperation, QueueStats, OperationType, ResourceType } from './QueueManager'
 import { getPerformanceMonitor } from '@/lib/performance/PerformanceMonitor'
+import { safeGet, safeSet } from '@/lib/storage/safeStorage'
 
 interface OptimizedQueueConfig {
   storageKey: string
@@ -443,10 +444,9 @@ export class OptimizedQueueManager {
   private async loadQueueMetadata(): Promise<void> {
     try {
       const metadataKey = `${this.config.storageKey}_metadata`
-      const stored = localStorage.getItem(metadataKey)
-      
-      if (stored) {
-        const metadata = JSON.parse(stored)
+      const metadata = safeGet<any>(metadataKey)
+
+      if (metadata) {
         this.stats.totalOperations = metadata.totalOperations || 0
         this.chunkIndex = new Map(metadata.chunkIndex || [])
       }
@@ -463,8 +463,8 @@ export class OptimizedQueueManager {
         chunkIndex: Array.from(this.chunkIndex.entries()),
         timestamp: Date.now()
       }
-      
-      localStorage.setItem(metadataKey, JSON.stringify(metadata))
+
+      safeSet(metadataKey, metadata)
     } catch (error) {
       console.warn('OptimizedQueueManager: Failed to save metadata:', error)
     }


### PR DESCRIPTION
## Summary
- add safeGet/safeSet helpers and storage cleanup utilities
- use safe storage helpers in queue, cache, and Supabase client code
- purge bad localStorage data on boot to prevent JSON.parse errors

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf478949288333b52d69d83d7f8ff9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Automatic storage cleanup on app launch to remove invalid saved data.

* Bug Fixes
  * Fixed rare crashes and blank states caused by malformed stored data.
  * Improved reliability of trip and profile caching with safer reads/writes.
  * Stabilized offline sync queues and progress tracking across reloads.
  * Reduced storage-related errors and quota issues with safer persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->