### PR TITLE
feat: strengthen sync lifecycle and mutation idempotency

### DIFF
--- a/src/components/dashboard/DraftTripsSection.tsx
+++ b/src/components/dashboard/DraftTripsSection.tsx
@@ -76,9 +76,12 @@ export default function DraftTripsSection({ onContinueTrip }: DraftTripsSectionP
     try {
       console.log('Deleting draft with ID:', draftId)
       
+      const mutationId = crypto.randomUUID()
       const response = await fetch(`/api/trips/drafts/${draftId}`, {
         method: 'DELETE',
-        credentials: 'include'
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ clientMutationId: mutationId })
       })
       
       console.log('Delete response status:', response.status)

--- a/src/components/dashboard/TripCard.tsx
+++ b/src/components/dashboard/TripCard.tsx
@@ -132,9 +132,12 @@ export default function TripCard({ trip, onClick, isPast = false }: TripCardProp
         const draftId = (trip as any).draftId
         console.log('Deleting draft with ID:', draftId)
         
+        const mutationId = crypto.randomUUID()
         response = await fetch(`/api/trips/drafts/${draftId}`, {
           method: 'DELETE',
-          credentials: 'include'
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ clientMutationId: mutationId })
         })
       } else {
         // Delete the actual trip

--- a/src/components/dashboard/tabs/OverviewTab.tsx
+++ b/src/components/dashboard/tabs/OverviewTab.tsx
@@ -105,7 +105,8 @@ export function OverviewTab({
     setIsDeleting(true)
     try {
       await removeTrip(trip.id)
-      await cancelTrip(trip.id, user?.id || '')
+      const mutationId = crypto.randomUUID()
+      await cancelTrip(trip.id, user?.id || '', mutationId)
       setShowDeleteConfirm(false)
       onClose?.()
       router.refresh()

--- a/src/contexts/TripCacheContext.tsx
+++ b/src/contexts/TripCacheContext.tsx
@@ -375,6 +375,7 @@ export function TripCacheProvider({ children }: TripCacheProviderProps) {
         resource: 'trip',
         resourceId: trip.id,
         data: trip,
+        mutationId: crypto.randomUUID(),
         timestamp: Date.now(),
         priority: 1,
         retryCount: 0
@@ -411,6 +412,7 @@ export function TripCacheProvider({ children }: TripCacheProviderProps) {
         resource: 'trip',
         resourceId: tripId,
         data: updates,
+        mutationId: crypto.randomUUID(),
         timestamp: Date.now(),
         priority: 2,
         retryCount: 0
@@ -443,6 +445,7 @@ export function TripCacheProvider({ children }: TripCacheProviderProps) {
         resource: 'trip',
         resourceId: tripId,
         data: undefined,
+        mutationId: crypto.randomUUID(),
         timestamp: Date.now(),
         priority: 3, // Higher priority for deletes
         retryCount: 0

--- a/src/lib/sync/QueueManager.ts
+++ b/src/lib/sync/QueueManager.ts
@@ -17,6 +17,7 @@ export interface QueuedOperation {
   resource: ResourceType
   resourceId?: string // For updates/deletes
   data?: any // Operation payload
+  mutationId?: string // Idempotency key for server-side deduplication
   timestamp: number
   priority: number // Lower number = higher priority
   retryCount: number

--- a/src/lib/trip-actions.ts
+++ b/src/lib/trip-actions.ts
@@ -5,8 +5,23 @@ import { createSupabaseServiceClient } from '@/lib/supabase-server'
 import { sendTripNotification } from '@/lib/send-trip-notification'
 
 // Finalize or create a trip and revalidate caches
-export async function createTrip(tripId: string, userId: string) {
+export async function createTrip(tripId: string, userId: string, clientMutationId?: string) {
   const supabase = createSupabaseServiceClient()
+
+  if (clientMutationId) {
+    const { error: mutationError } = await supabase
+      .from('mutations')
+      .insert({ id: clientMutationId, user_id: userId, operation: 'create_trip' })
+      .select('id')
+      .single()
+    if (mutationError) {
+      if (mutationError.code === '23505') {
+        return null
+      }
+      throw new Error(mutationError.message)
+    }
+  }
+
   // Touch the trip record to ensure updated_at changes and data is persisted
   const { data, error } = await supabase
     .from('trips')
@@ -26,8 +41,23 @@ export async function createTrip(tripId: string, userId: string) {
 }
 
 // Cancel a trip by setting its status to cancelled and revalidating caches
-export async function cancelTrip(tripId: string, userId: string) {
+export async function cancelTrip(tripId: string, userId: string, clientMutationId?: string) {
   const supabase = createSupabaseServiceClient()
+
+  if (clientMutationId) {
+    const { error: mutationError } = await supabase
+      .from('mutations')
+      .insert({ id: clientMutationId, user_id: userId, operation: 'cancel_trip' })
+      .select('id')
+      .single()
+    if (mutationError) {
+      if (mutationError.code === '23505') {
+        return { success: true }
+      }
+      throw new Error(mutationError.message)
+    }
+  }
+
   const { error } = await supabase
     .from('trips')
     .update({ status: 'cancelled' })


### PR DESCRIPTION
## Summary
- protect SyncManager from transient failures with retry backoff
- attach mutation IDs to queue operations and server actions for idempotency
- filter draft trips and clear stale selection from dashboard list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bf48eaecb483339f4bb7a21ee25e0a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Safer actions with idempotency to prevent duplicate trip creates/cancels/deletes, improving reliability (including offline sync).
  * Draft trips are now integrated into the dashboard’s current trips with clear draft status; loading message updated to “Loading trips...”.
  * Trips API supports excluding drafts via a flag and now returns user permission info in responses.

* Bug Fixes
  * Eliminates duplicate trips in dashboard listings.
  * Planning (draft) trips no longer appear in Past Trips.
  * More consistent cache refresh after deleting trips or drafts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->