### PR TITLE
Avoid unnecessary route refreshes

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -13,13 +13,11 @@ import type { TripCard as TripCardType } from '@/types'
 import { cn, getTripStatus } from '@/lib/utils'
 import { useSmartTrips } from '@/hooks/useSmartTrips'
 import { useRequireAuth, useAuth } from '@/contexts/AuthContext'
-import { useRouter } from 'next/navigation'
 import { createTrip } from '@/lib/trip-actions'
 
 export default function Dashboard() {
     const { isAuthenticated, isLoading: authLoading } = useRequireAuth()
     const { user } = useAuth() // Get user data for permission checks
-    const router = useRouter()
     const [selectedTrip, setSelectedTrip] = useState<TripCardType | null>(null)
     const [isMenuOpen, setIsMenuOpen] = useState(false)
     const [showTripCreationModal, setShowTripCreationModal] = useState(false)
@@ -236,7 +234,7 @@ export default function Dashboard() {
     await addTripOptimistically(trip)
     const mutationId = crypto.randomUUID()
     await createTrip(trip.id, user?.id || '', mutationId)
-    router.refresh()
+    await refreshSilently()
   }
 
   const closeModal = () => {

--- a/src/components/dashboard/tabs/OverviewTab.tsx
+++ b/src/components/dashboard/tabs/OverviewTab.tsx
@@ -11,10 +11,8 @@ import { calculateDuration } from '@/lib/utils'
 import type { TripCard } from '@/types'
 import type { TabValidationState } from '@/types/enhanced-modal'
 import ConfirmationModal from '@/components/ui/ConfirmationModal'
-import { useRouter } from 'next/navigation'
 import { useAuth } from '@/contexts/AuthContext'
 import { useTripActions } from '@/hooks/useSmartTrips'
-import { cancelTrip } from '@/lib/trip-actions'
 
 interface OverviewTabProps {
   trip: TripCard
@@ -65,7 +63,6 @@ export function OverviewTab({
 
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
-  const router = useRouter()
   const { user } = useAuth()
   const { removeTrip } = useTripActions()
 
@@ -105,11 +102,8 @@ export function OverviewTab({
     setIsDeleting(true)
     try {
       await removeTrip(trip.id)
-      const mutationId = crypto.randomUUID()
-      await cancelTrip(trip.id, user?.id || '', mutationId)
       setShowDeleteConfirm(false)
       onClose?.()
-      router.refresh()
     } catch (error) {
       console.error('Delete trip error:', error)
     } finally {

--- a/src/components/trips/DriverVehicleStep.tsx
+++ b/src/components/trips/DriverVehicleStep.tsx
@@ -1,7 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import type { TripFormData } from './TripCreationModal'
 import type { User, Vehicle } from '@/types'
-import { useRouter } from 'next/navigation'
 
 interface Props {
   formData: TripFormData
@@ -14,7 +13,6 @@ export default function DriverVehicleStep({ formData, updateFormData }: Props) {
   const [showInvite, setShowInvite] = useState(false)
   const [inviteName, setInviteName] = useState('')
   const [inviteEmail, setInviteEmail] = useState('')
-  const router = useRouter()
 
   useEffect(() => {
     const load = async () => {
@@ -64,7 +62,6 @@ export default function DriverVehicleStep({ formData, updateFormData }: Props) {
       if (data.user) {
         setDrivers(prev => [...prev, data.user])
         updateFormData({ drivers: [data.user] })
-        router.refresh()
       }
     } catch (err) {
       console.error('Invite driver failed', err)

--- a/src/contexts/TripCacheContext.tsx
+++ b/src/contexts/TripCacheContext.tsx
@@ -264,7 +264,11 @@ export function TripCacheProvider({ children }: TripCacheProviderProps) {
   const refreshTrips = useCallback(async (options: { force?: boolean } = {}) => {
     const measureDashboardLoad = measurePerformance('dashboard_load', async () => {
       try {
-        setState(prev => ({ ...prev, loading: true, error: null }))
+        setState(prev => ({
+          ...prev,
+          loading: options.force || prev.trips.length === 0,
+          error: null
+        }))
         
         // Start cache hit/miss measurement
         performanceOptimizer.startMeasurement('cache_lookup')


### PR DESCRIPTION
## Summary
- replace `router.refresh()` after trip creation with `refreshSilently()` to preserve existing trip cards
- consolidate trip cancellation to use optimistic delete only and drop full route refresh
- keep cached trips visible during background updates by only enabling the loading state when necessary
- remove extraneous route refresh when inviting drivers

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bf7a9cbcf883339150a7a9a1d3ec81