### PR TITLE
Improve itinerary email domain and presentation

### DIFF
--- a/src/app/api/emails/test/route.ts
+++ b/src/app/api/emails/test/route.ts
@@ -99,7 +99,10 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+      || (process.env.NODE_ENV === 'development'
+        ? 'http://localhost:3000'
+        : 'https://trips.wolthers.com')
     const defaultTripData = {
       title: tripData?.title || 'Test Trip - Email System Check',
       accessCode: tripData?.accessCode || 'TEST_EMAIL_2024'
@@ -136,12 +139,16 @@ export async function POST(request: NextRequest) {
                   {
                     time: '09:00',
                     title: 'Morning Meeting',
-                    location: 'Coffee Farm HQ'
+                    type: 'visit',
+                    hostName: 'Coffee Farm HQ Team',
+                    duration: '60 minutes'
                   },
                   {
                     time: '14:00',
                     title: 'Farm Tour',
-                    location: 'Main Processing Facility'
+                    type: 'visit',
+                    hostName: 'Farm Operations',
+                    duration: '90 minutes'
                   }
                 ]
               },
@@ -151,7 +158,9 @@ export async function POST(request: NextRequest) {
                   {
                     time: '10:00',
                     title: 'Cupping Session',
-                    location: 'Quality Lab'
+                    type: 'visit',
+                    hostName: 'Quality Lab Team',
+                    duration: '75 minutes'
                   }
                 ]
               }

--- a/src/app/api/visit-response/route.ts
+++ b/src/app/api/visit-response/route.ts
@@ -12,7 +12,10 @@ export async function GET(request: NextRequest) {
   }
 
   const supabase = createSupabaseServiceClient()
-  const baseUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://localhost:3000'
+  const baseUrl = process.env.NEXT_PUBLIC_APP_URL
+    || (process.env.NODE_ENV === 'development'
+      ? 'http://localhost:3000'
+      : 'https://trips.wolthers.com')
 
   try {
     // 2. Update the status of the corresponding meeting in the database.


### PR DESCRIPTION
## Summary
- resolve email base URLs to use https://trips.wolthers.com by default while keeping local development support
- refresh the itinerary email design to remove address clutter, surface host details, and render the content inside a modern card layout
- include host assignments when building itinerary activity data and update host confirmation links to use the new base URL

## Testing
- npm run lint *(fails: Missing script "lint")*
- npx tsc --noEmit *(fails: existing project-wide type errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6332064c8333829f3de62fbdaddd